### PR TITLE
Dynamic Range Attribute

### DIFF
--- a/LinkDotNet.ValidationExtensions.Tests/Dynamic/DynamicRangeTests.cs
+++ b/LinkDotNet.ValidationExtensions.Tests/Dynamic/DynamicRangeTests.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using Xunit;
+
+namespace LinkDotNet.ValidationExtensions.Tests;
+
+public class DynamicRangeTests
+{
+    [Fact(DisplayName = "Should not be valid if 'MinimumWeight' is grather than 'MaximumWeight'")]
+    public static void ShouldNotBeValidIfMinimumIsGratherThanMaximum()
+    {
+        var data = new Model(2, 1);
+        var context = new ValidationContext(data);
+        var results = new List<ValidationResult>();
+
+        var isValid = Validator.TryValidateObject(data, context, results, true);
+
+        isValid.Should().BeFalse();
+        results.Should().HaveCount(2);
+        results[0].ErrorMessage.Should().Be("The field MinimumWeight must be between 0.1 and 1.");
+        results[1].ErrorMessage.Should().Be("The field MaximumWeight must be between 2 and 5.2.");
+    }
+
+    [Fact(DisplayName = "Should be valid if 'MaximumWeight' is grather than 'MinimumWeight'")]
+    public static void ShouldBeValidIfMaximumIsGratherThanMinimum()
+    {
+        var data = new Model(1, 2);
+        var context = new ValidationContext(data);
+        var results = new List<ValidationResult>();
+
+        var isValid = Validator.TryValidateObject(data, context, results, true);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'MinimumWeight' is null")]
+    public static void MustThrowsInvalidOperationExceptionWhenMinimumWeightIsNull()
+    {
+        var data = new Model(null, 2);
+        var context = new ValidationContext(data);
+        var attribute = new DynamicRangeAttribute(typeof(decimal), "MinimumWeight", "5.2");
+
+        var action = () => attribute.Validate("Any", context);
+
+        action.Should()
+              .Throw<InvalidOperationException>()
+              .WithMessage("The value of 'MinimumWeight' property cannot be null (introduced for 'Minimum' in range).");
+    }
+
+    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'MaximumWeight' is null")]
+    public static void MustThrowsInvalidOperationExceptionWhenMaximumWeightIsNull()
+    {
+        var data = new Model(2, null);
+        var context = new ValidationContext(data);
+        var attribute = new DynamicRangeAttribute(typeof(decimal), "0.1", "MaximumWeight");
+
+        var action = () => attribute.Validate("Any", context);
+
+        action.Should()
+              .Throw<InvalidOperationException>()
+              .WithMessage("The value of 'MaximumWeight' property cannot be null (introduced for 'Maximum' in range).");
+    }
+
+    [Fact(DisplayName = "Must throws 'ArgumentNullException' when 'Minimum' is empty")]
+    public static void MustThrowsArgumentNullExceptionWhenMinimumIsEmpty()
+    {
+        var attribute = new DynamicRangeAttribute(typeof(decimal), string.Empty, "5.2");
+
+        var action = () => attribute.Validate("Any", new ValidationContext(new object()));
+
+        action.Should()
+              .Throw<ArgumentNullException>()
+              .WithMessage("Value cannot be null. (Parameter 'Minimum')");
+    }
+
+    [Fact(DisplayName = "Must throws 'ArgumentNullException' when 'Maximum' is empty")]
+    public static void MustThrowsArgumentNullExceptionWhenMaximumIsEmpty()
+    {
+        var attribute = new DynamicRangeAttribute(typeof(decimal), "0.1", string.Empty);
+
+        var action = () => attribute.Validate("Any", new ValidationContext(new object()));
+
+        action.Should()
+              .Throw<ArgumentNullException>()
+              .WithMessage("Value cannot be null. (Parameter 'Maximum')");
+    }
+
+    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'Minimum' PropertyType and OperandType not the same")]
+    public static void MustThrowsInvalidOperationExceptionWhenMinimumPropertyTypeAndOperandTypeNotTheSame()
+    {
+        var data = new ModelWrongMinimumPropertyType(1, 5);
+        var context = new ValidationContext(data);
+
+        var action = () => Validator.ValidateObject(data, context, true);
+
+        action.Should()
+              .Throw<InvalidOperationException>()
+              .WithMessage("The 'MinimumWeight' type must be the same as the OperandType (introduced for 'Minimum' in range).");
+    }
+
+    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'Maximum' PropertyType and OperandType not the same")]
+    public static void MustThrowsInvalidOperationExceptionWhenMaximumPropertyTypeAndOperandTypeNotTheSame()
+    {
+        var data = new ModelWrongMaximumPropertyType(1, 5);
+        var context = new ValidationContext(data);
+
+        var action = () => Validator.ValidateObject(data, context, true);
+
+        action.Should()
+              .Throw<InvalidOperationException>()
+              .WithMessage("The 'MaximumWeight' type must be the same as the OperandType (introduced for 'Maximum' in range).");
+    }
+
+    public class Model
+    {
+        public Model(decimal? minimumWeight, decimal? maximumWeight)
+        {
+            MinimumWeight = minimumWeight;
+            MaximumWeight = maximumWeight;
+        }
+
+        [DynamicRange(type: typeof(decimal), minimum: "0.1", maximum: nameof(MaximumWeight))]
+        public decimal? MinimumWeight { get; set; }
+
+        [DynamicRange(type: typeof(decimal), minimum: nameof(MinimumWeight), maximum: "5.2")]
+        public decimal? MaximumWeight { get; set; }
+    }
+
+    public class ModelWrongMaximumPropertyType
+    {
+        public ModelWrongMaximumPropertyType(decimal? minimumWeight, double? maximumWeight)
+        {
+            MinimumWeight = minimumWeight;
+            MaximumWeight = maximumWeight;
+        }
+
+        [DynamicRange(type: typeof(decimal), minimum: "0.1", maximum: nameof(MaximumWeight))]
+        public decimal? MinimumWeight { get; set; }
+
+        public double? MaximumWeight { get; set; }
+    }
+
+    public class ModelWrongMinimumPropertyType
+    {
+        public ModelWrongMinimumPropertyType(double? minimumWeight, decimal? maximumWeight)
+        {
+            MinimumWeight = minimumWeight;
+            MaximumWeight = maximumWeight;
+        }
+
+        public double? MinimumWeight { get; set; }
+
+        [DynamicRange(type: typeof(decimal), minimum: nameof(MinimumWeight), maximum: "5.2")]
+        public decimal? MaximumWeight { get; set; }
+    }
+}

--- a/LinkDotNet.ValidationExtensions.Tests/Dynamic/DynamicRangeTests.cs
+++ b/LinkDotNet.ValidationExtensions.Tests/Dynamic/DynamicRangeTests.cs
@@ -8,8 +8,8 @@ namespace LinkDotNet.ValidationExtensions.Tests;
 
 public class DynamicRangeTests
 {
-    [Fact(DisplayName = "Should not be valid if 'MinimumWeight' is grather than 'MaximumWeight'")]
-    public static void ShouldNotBeValidIfMinimumIsGratherThanMaximum()
+    [Fact(DisplayName = "Should not be valid if 'MinimumWeight' is greater than 'MaximumWeight'")]
+    public static void ShouldNotBeValidIfMinimumIsGreaterThanMaximum()
     {
         var data = new Model(2, 1);
         var context = new ValidationContext(data);
@@ -23,8 +23,8 @@ public class DynamicRangeTests
         results[1].ErrorMessage.Should().Be("The field MaximumWeight must be between 2 and 5.2.");
     }
 
-    [Fact(DisplayName = "Should be valid if 'MaximumWeight' is grather than 'MinimumWeight'")]
-    public static void ShouldBeValidIfMaximumIsGratherThanMinimum()
+    [Fact(DisplayName = "Should be valid if 'MaximumWeight' is greater than 'MinimumWeight'")]
+    public static void ShouldBeValidIfMaximumIsGreaterThanMinimum()
     {
         var data = new Model(1, 2);
         var context = new ValidationContext(data);

--- a/LinkDotNet.ValidationExtensions.Tests/Dynamic/DynamicRangeTests.cs
+++ b/LinkDotNet.ValidationExtensions.Tests/Dynamic/DynamicRangeTests.cs
@@ -35,12 +35,12 @@ public class DynamicRangeTests
         isValid.Should().BeTrue();
     }
 
-    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'MinimumWeight' is null")]
-    public static void MustThrowsInvalidOperationExceptionWhenMinimumWeightIsNull()
+    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'Minimum Property Value' is null")]
+    public static void MustThrowsInvalidOperationExceptionWhenMinimumPropertyValueIsNull()
     {
         var data = new Model(null, 2);
         var context = new ValidationContext(data);
-        var attribute = new DynamicRangeAttribute(typeof(decimal), "MinimumWeight", "5.2");
+        var attribute = new DynamicRangeAttribute(typeof(decimal), "MinimumWeight", 5.2);
 
         var action = () => attribute.Validate("Any", context);
 
@@ -49,12 +49,12 @@ public class DynamicRangeTests
               .WithMessage("The value of 'MinimumWeight' property cannot be null (introduced for 'Minimum' in range).");
     }
 
-    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'MaximumWeight' is null")]
-    public static void MustThrowsInvalidOperationExceptionWhenMaximumWeightIsNull()
+    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'Maximum Property Value' is null")]
+    public static void MustThrowsInvalidOperationExceptionWhenMaximumPropertyValueIsNull()
     {
         var data = new Model(2, null);
         var context = new ValidationContext(data);
-        var attribute = new DynamicRangeAttribute(typeof(decimal), "0.1", "MaximumWeight");
+        var attribute = new DynamicRangeAttribute(typeof(decimal), 0.1, "MaximumWeight");
 
         var action = () => attribute.Validate("Any", context);
 
@@ -63,28 +63,56 @@ public class DynamicRangeTests
               .WithMessage("The value of 'MaximumWeight' property cannot be null (introduced for 'Maximum' in range).");
     }
 
-    [Fact(DisplayName = "Must throws 'ArgumentNullException' when 'Minimum' is empty")]
-    public static void MustThrowsArgumentNullExceptionWhenMinimumIsEmpty()
+    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'Minimum PropertyName' is null or empty")]
+    public static void MustThrowsInvalidOperationExceptionWhenMinimumPropertyNameIsNullOrEmpty()
     {
-        var attribute = new DynamicRangeAttribute(typeof(decimal), string.Empty, "5.2");
+        var attribute = new DynamicRangeAttribute(typeof(decimal), string.Empty, 5.2);
 
         var action = () => attribute.Validate("Any", new ValidationContext(new object()));
 
         action.Should()
-              .Throw<ArgumentNullException>()
-              .WithMessage("Value cannot be null. (Parameter 'Minimum')");
+              .Throw<InvalidOperationException>()
+              .WithMessage("The 'Minimum PropertyName' cannot be null or empty.");
     }
 
-    [Fact(DisplayName = "Must throws 'ArgumentNullException' when 'Maximum' is empty")]
-    public static void MustThrowsArgumentNullExceptionWhenMaximumIsEmpty()
+    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'Maximum PropertyName' is null or empty")]
+    public static void MustThrowsInvalidOperationExceptionWhenMaximumPropertyNameIsNullOrEmpty()
     {
-        var attribute = new DynamicRangeAttribute(typeof(decimal), "0.1", string.Empty);
+        var attribute = new DynamicRangeAttribute(typeof(decimal), 0.1, string.Empty);
 
         var action = () => attribute.Validate("Any", new ValidationContext(new object()));
 
         action.Should()
-              .Throw<ArgumentNullException>()
-              .WithMessage("Value cannot be null. (Parameter 'Maximum')");
+              .Throw<InvalidOperationException>()
+              .WithMessage("The 'Maximum PropertyName' cannot be null or empty.");
+    }
+
+    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'Minimum' PropertyName is wrong")]
+    public static void MustThrowsInvalidOperationExceptionWhenMinimumPropertyNameIsWrong()
+    {
+        var data = new Model(1, 2);
+        var context = new ValidationContext(data);
+        var attribute = new DynamicRangeAttribute(typeof(decimal), "WRONG", 5.2);
+
+        var action = () => attribute.Validate("Any", context);
+
+        action.Should()
+              .Throw<InvalidOperationException>()
+              .WithMessage("The 'WRONG' property not found (introduced for 'Minimum' in range).");
+    }
+
+    [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'Maximum' PropertyName is wrong")]
+    public static void MustThrowsInvalidOperationExceptionWhenMaximumPropertyNameIsWrong()
+    {
+        var data = new Model(1, 2);
+        var context = new ValidationContext(data);
+        var attribute = new DynamicRangeAttribute(typeof(decimal), 0.1, "WRONG");
+
+        var action = () => attribute.Validate("Any", context);
+
+        action.Should()
+              .Throw<InvalidOperationException>()
+              .WithMessage("The 'WRONG' property not found (introduced for 'Maximum' in range).");
     }
 
     [Fact(DisplayName = "Must throws 'InvalidOperationException' when 'Minimum' PropertyType and OperandType not the same")]
@@ -121,10 +149,10 @@ public class DynamicRangeTests
             MaximumWeight = maximumWeight;
         }
 
-        [DynamicRange(type: typeof(decimal), minimum: "0.1", maximum: nameof(MaximumWeight))]
+        [DynamicRange(type: typeof(decimal), minimum: 0.1, maximumPropertyName: nameof(MaximumWeight))]
         public decimal? MinimumWeight { get; set; }
 
-        [DynamicRange(type: typeof(decimal), minimum: nameof(MinimumWeight), maximum: "5.2")]
+        [DynamicRange(type: typeof(decimal), minimumPropertyName: nameof(MinimumWeight), maximum: 5.2)]
         public decimal? MaximumWeight { get; set; }
     }
 
@@ -136,7 +164,7 @@ public class DynamicRangeTests
             MaximumWeight = maximumWeight;
         }
 
-        [DynamicRange(type: typeof(decimal), minimum: "0.1", maximum: nameof(MaximumWeight))]
+        [DynamicRange(type: typeof(decimal), minimum: 0.1, maximumPropertyName: nameof(MaximumWeight))]
         public decimal? MinimumWeight { get; set; }
 
         public double? MaximumWeight { get; set; }
@@ -152,7 +180,7 @@ public class DynamicRangeTests
 
         public double? MinimumWeight { get; set; }
 
-        [DynamicRange(type: typeof(decimal), minimum: nameof(MinimumWeight), maximum: "5.2")]
+        [DynamicRange(type: typeof(decimal), minimumPropertyName: nameof(MinimumWeight), maximum: 5.2)]
         public decimal? MaximumWeight { get; set; }
     }
 }

--- a/LinkDotNet.ValidationExtensions/Dynamic/DynamicRangeAttribute.cs
+++ b/LinkDotNet.ValidationExtensions/Dynamic/DynamicRangeAttribute.cs
@@ -43,6 +43,22 @@ public class DynamicRangeAttribute : ValidationAttribute
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="DynamicRangeAttribute"/> class.
+    /// Allows for specifying range for arbitrary types. The minimum and maximum strings
+    /// will be converted to the target type.
+    /// </summary>
+    /// <param name="type">The type of the range parameters. Must implement IComparable.</param>
+    /// <param name="minimumPropertyName">The property-name of minimum.</param>
+    /// <param name="maximumPropertyName">The property-name of maximum.</param>
+    public DynamicRangeAttribute(Type type, string minimumPropertyName, string maximumPropertyName)
+       : base()
+    {
+        OperandType = type;
+        getMinimum = (ValidationContext validationContext) => GetActualValue(validationContext, OperandType, "Minimum", minimumPropertyName);
+        getMaximum = (ValidationContext validationContext) => GetActualValue(validationContext, OperandType, "Maximum", maximumPropertyName);
+    }
+
+    /// <summary>
     /// Gets the type of the <see cref="Minimum" /> and <see cref="Maximum" /> values
     /// (e.g. Int32, Double, or some custom type).
     /// </summary>

--- a/LinkDotNet.ValidationExtensions/Dynamic/DynamicRangeAttribute.cs
+++ b/LinkDotNet.ValidationExtensions/Dynamic/DynamicRangeAttribute.cs
@@ -16,13 +16,13 @@ public class DynamicRangeAttribute : ValidationAttribute
     /// will be converted to the target type.
     /// </summary>
     /// <param name="type">The type of the range parameters. Must implement IComparable.</param>
-    /// <param name="minimum">The minimum allowable value.</param>
+    /// <param name="minimumPropertyName">The property-name of minimum.</param>
     /// <param name="maximumPropertyName">The property-name of maximum.</param>
-    public DynamicRangeAttribute(Type type, object minimum, string maximumPropertyName)
-        : base()
+    public DynamicRangeAttribute(Type type, string minimumPropertyName, string maximumPropertyName)
+       : base()
     {
         OperandType = type;
-        getMinimum = (ValidationContext validationContext) => minimum;
+        getMinimum = (ValidationContext validationContext) => GetActualValue(validationContext, OperandType, "Minimum", minimumPropertyName);
         getMaximum = (ValidationContext validationContext) => GetActualValue(validationContext, OperandType, "Maximum", maximumPropertyName);
     }
 
@@ -48,13 +48,13 @@ public class DynamicRangeAttribute : ValidationAttribute
     /// will be converted to the target type.
     /// </summary>
     /// <param name="type">The type of the range parameters. Must implement IComparable.</param>
-    /// <param name="minimumPropertyName">The property-name of minimum.</param>
+    /// <param name="minimum">The minimum allowable value.</param>
     /// <param name="maximumPropertyName">The property-name of maximum.</param>
-    public DynamicRangeAttribute(Type type, string minimumPropertyName, string maximumPropertyName)
-       : base()
+    public DynamicRangeAttribute(Type type, object minimum, string maximumPropertyName)
+        : base()
     {
         OperandType = type;
-        getMinimum = (ValidationContext validationContext) => GetActualValue(validationContext, OperandType, "Minimum", minimumPropertyName);
+        getMinimum = (ValidationContext validationContext) => minimum;
         getMaximum = (ValidationContext validationContext) => GetActualValue(validationContext, OperandType, "Maximum", maximumPropertyName);
     }
 
@@ -68,8 +68,8 @@ public class DynamicRangeAttribute : ValidationAttribute
     /// <inheritdoc />
     protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
-        var minimumAsText = getMinimum.Invoke(validationContext).ToString();
-        var maximumAsText = getMaximum.Invoke(validationContext).ToString();
+        var minimumAsText = getMinimum.Invoke(validationContext).ToString()!;
+        var maximumAsText = getMaximum.Invoke(validationContext).ToString()!;
 
         // Create RangeAttribute instance for validate value in actual range
         var rangeAttribute = new RangeAttribute(OperandType, minimumAsText, maximumAsText);

--- a/LinkDotNet.ValidationExtensions/Dynamic/DynamicRangeAttribute.cs
+++ b/LinkDotNet.ValidationExtensions/Dynamic/DynamicRangeAttribute.cs
@@ -1,0 +1,136 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace LinkDotNet.ValidationExtensions;
+
+/// <summary>
+/// Used for specifying a range that accepts another property-name for 'Minimum' or 'Maximum'.
+/// </summary>
+public class DynamicRangeAttribute : ValidationAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DynamicRangeAttribute"/> class.
+    ///     Allows for specifying range for arbitrary types. The minimum and maximum strings
+    ///     will be converted to the target type.
+    /// </summary>
+    /// <param name="type">The type of the range parameters. Must implement IComparable.</param>
+    /// <param name="minimum">The minimum allowable value or property-name.</param>
+    /// <param name="maximum">The maximum allowable value or property-name.</param>
+    public DynamicRangeAttribute(Type type, string minimum, string maximum)
+        : base()
+    {
+        OperandType = type;
+        Minimum = minimum;
+        Maximum = maximum;
+    }
+
+    /// <summary>
+    /// Gets the type of the <see cref="Minimum" /> and <see cref="Maximum" /> values
+    /// (e.g. Int32, Double, or some custom type).
+    /// </summary>
+    /// <value> The type of the <see cref="Minimum" /> and <see cref="Maximum" /> values. </value>
+    public Type OperandType { get; }
+
+    /// <summary>
+    /// Gets the minimum value for the range or another property-name.
+    /// </summary>
+    /// <value> The minimum value for the range or another property-name. </value>
+    public string Minimum { get; private set; }
+
+    /// <summary>
+    /// Gets the maximum value for the range or another property-name.
+    /// </summary>
+    /// <value> The maximum value for the range or another property-name. </value>
+    public string Maximum { get; private set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether string values for <see cref="Minimum"/> and <see cref="Maximum"/>
+    /// are parsed in the invariant culture rather than the current culture in effect at the time of the validation
+    /// (<see cref="RangeAttribute.ParseLimitsInInvariantCulture"/>).
+    /// </summary>
+    /// <value> A value for <see cref="RangeAttribute.ParseLimitsInInvariantCulture"/>. </value>
+    public bool ParseLimitsInInvariantCulture { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether any conversions necessary from the value being validated to <see cref="OperandType"/>
+    /// as set by the <c>type</c> parameter of the <see cref="DynamicRangeAttribute(Type, string, string)"/> constructor are carried
+    /// out in the invariant culture rather than the current culture in effect at the time of the validation.
+    /// (<see cref="RangeAttribute.ConvertValueInInvariantCulture"/>).
+    /// </summary>
+    /// <value> A value for <see cref="RangeAttribute.ConvertValueInInvariantCulture"/>. </value>
+    public bool ConvertValueInInvariantCulture { get; set; }
+
+    /// <inheritdoc />
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        // Get actual value of minimum and maximum
+        Minimum = GetActualValue(validationContext, OperandType, nameof(Minimum), Minimum);
+        Maximum = GetActualValue(validationContext, OperandType, nameof(Maximum), Maximum);
+
+        // Create RangeAttribute instance for validate value in actual range
+        var rangeAttribute = new RangeAttribute(OperandType, Minimum, Maximum)
+        {
+            ParseLimitsInInvariantCulture = ParseLimitsInInvariantCulture,
+            ConvertValueInInvariantCulture = ConvertValueInInvariantCulture,
+        };
+
+        if (ErrorMessage is not null)
+        {
+            rangeAttribute.ErrorMessage = ErrorMessage;
+        }
+
+        if (ErrorMessageResourceName is not null)
+        {
+            rangeAttribute.ErrorMessageResourceName = ErrorMessageResourceName;
+        }
+
+        if (ErrorMessageResourceType is not null)
+        {
+            rangeAttribute.ErrorMessageResourceType = ErrorMessageResourceType;
+        }
+
+        return rangeAttribute.GetValidationResult(value, validationContext);
+    }
+
+    /// <summary>
+    /// Get actual value of subject.
+    /// </summary>
+    /// <param name="validationContext">
+    /// A <see cref="ValidationContext" /> instance that provides
+    /// context about the validation operation, such as the object and member being validated.
+    /// </param>
+    /// <param name="subjectType"> The type of subject. </param>
+    /// <param name="subjectName"> The name of subject. </param>
+    /// <param name="propertyNameOrValue"> The propertyName or value of subject. </param>
+    /// <returns> The actual value of subject. </returns>
+    /// <exception cref="ArgumentNullException"> is thrown when propertyNameOrValue is null or nothing. </exception>
+    /// <exception cref="InvalidOperationException"> is thrown when PropertyType of propertyName has not been the same as OperandType.</exception>
+    private static string GetActualValue(ValidationContext validationContext, Type subjectType, string subjectName, string propertyNameOrValue)
+    {
+        if (string.IsNullOrWhiteSpace(propertyNameOrValue))
+        {
+            throw new ArgumentNullException(subjectName);
+        }
+
+        var propertyInfo = validationContext.ObjectType.GetProperty(propertyNameOrValue);
+
+        if (propertyInfo is null)
+        {
+            return propertyNameOrValue;
+        }
+
+        if (propertyInfo.PropertyType != subjectType)
+        {
+            throw new InvalidOperationException($"The {subjectName} PropertyType must be the same as the OperandType.");
+        }
+
+        var value = propertyInfo.GetValue(validationContext.ObjectInstance, null)?.ToString();
+
+        if (value is null)
+        {
+            throw new InvalidOperationException($"The value of '{propertyNameOrValue}' property cannot be null (introduced for '{subjectName}' in range).");
+        }
+
+        return value;
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -65,10 +65,10 @@ public class BlogArticle
     [RequiredDynamic(nameof(ValidateRequired_NoticeByEmail), "Notice by email is activated")]
     public string? EmailAddress { get; set; }
     
-    [DynamicRange(typeof(decimal), minimum: "9.99", maximum: nameof(MaximumPrice))]
+    [DynamicRange(typeof(decimal), minimum: 9.99, maximumPropertyName: nameof(MaximumPrice))]
     public decimal? MinimumPrice { get; set; }
 
-    [DynamicRange(typeof(decimal), minimum: nameof(MinimumPrice), maximum: "199.99")]
+    [DynamicRange(typeof(decimal), minimumPropertyName: nameof(MinimumPrice), maximum: 199.99)]
     public decimal? MaximumPrice { get; set; }
 
     private static bool ValidateRequired_NoticeByEmail(BlogArticle value)

--- a/Readme.md
+++ b/Readme.md
@@ -65,6 +65,12 @@ public class BlogArticle
     [RequiredDynamic(nameof(ValidateRequired_NoticeByEmail), "Notice by email is activated")]
     public string? EmailAddress { get; set; }
     
+    [DynamicRange(typeof(decimal), minimum: "9.99", maximum: nameof(MaximumPrice))]
+    public decimal? MinimumPrice { get; set; }
+
+    [DynamicRange(typeof(decimal), minimum: nameof(MinimumPrice), maximum: "199.99")]
+    public decimal? MaximumPrice { get; set; }
+
     private static bool ValidateRequired_NoticeByEmail(BlogArticle value)
     {
         if (!value.NoticeByEmail.HasValue)
@@ -85,8 +91,7 @@ public class BlogArticle
         {
             return false;
         }
-    }    
-    
+    }
 }
 ```
 
@@ -97,3 +102,4 @@ public class BlogArticle
  * `MinIf` / `MaxIf`
  * `Min` / `Max`
  * `Dynamic`
+ * `DynamicRange`


### PR DESCRIPTION
Hi @linkdotnet, 
Last week, I had a situation with `RangeAttribute`.
There were two decimal properties as `Minimum` and `Maximum`. Each property must be in a range, so I used `RangeAttribute`.
But my model could be wrong if `Minimum` is greater than `Maximum` so I developed this class.
Well, if it seems appropriate, please merge it with the main project.
